### PR TITLE
Fix gitignore to correctly ignore the dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
 # Packaging
-.dist/
+dist/
 build/
 *.egg-info/


### PR DESCRIPTION
The .gitignore file was incorrectly named `gitignore` and contained an entry for `.dist/`, which did not match the actual `dist/` distribution directory.

This change renames the file to the standard `.gitignore` and updates the entry to correctly ignore the `dist/` directory.